### PR TITLE
Updateing package name for Arch Linux

### DIFF
--- a/projects/pycangjie/install.md
+++ b/projects/pycangjie/install.md
@@ -14,7 +14,7 @@ If it works for you and you like it, please don't hesitate to vote it on
 So you can install it with `yaourt`:
 
 ```
-$ yaourt pycangjie
+$ yaourt python-pycangjie
 ```
 
 ## Debian Unstable / Sid


### PR DESCRIPTION
The package name in Arch Linux. The old one still exists but deprecated and unsupported.